### PR TITLE
Organize code into src/ structure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,13 @@ dependencies = [
     "pyspark<4.0",
 ]
 
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
 [project.optional-dependencies]
 dev = [
     "pytest>=8.4.0",

--- a/src/pyspark_transform_registry/__init__.py
+++ b/src/pyspark_transform_registry/__init__.py
@@ -1,0 +1,19 @@
+"""
+PySpark Transform Registry - A package for logging and managing PySpark transform functions with MLflow.
+"""
+
+from .core import (
+    find_transform_versions,
+    load_transform_function,
+    log_transform_function,
+)
+from .metadata import _resolve_fully_qualified_name
+from .validation import validate_transform_input
+
+__all__ = [
+    "log_transform_function",
+    "load_transform_function", 
+    "find_transform_versions",
+    "validate_transform_input",
+    "_resolve_fully_qualified_name",
+]

--- a/src/pyspark_transform_registry/core.py
+++ b/src/pyspark_transform_registry/core.py
@@ -3,71 +3,15 @@ import importlib.util
 import inspect
 import json
 import os
-import pydoc
 import tempfile
-import typing
-from typing import Callable, Optional
+from typing import Callable
 
 import mlflow
 from pyspark.sql import SparkSession
 
+from .metadata import _get_function_metadata, _wrap_function_source
+
 spark = SparkSession.getActiveSession()
-
-
-def _resolve_fully_qualified_name(obj):
-    if obj is None:
-        return None
-    module = obj.__module__
-    qualname = getattr(obj, "__qualname__", obj.__name__)
-    return f"{module}.{qualname}"
-
-
-def _get_function_metadata(func: Callable):
-    """
-    Extracts parameter information, return type annotation, and docstring from a function.
-    """
-    sig = inspect.signature(func)
-    hints = typing.get_type_hints(func)
-    param_info = []
-    for name, param in sig.parameters.items():
-        annotation = hints.get(name)
-        param_info.append(
-            {
-                "name": name,
-                "annotation": _resolve_fully_qualified_name(annotation)
-                if annotation
-                else None,
-                "default": param.default if param.default != inspect._empty else None,
-            },
-        )
-    return_type = hints.get("return")
-    return_annot = _resolve_fully_qualified_name(return_type) if return_type else None
-    doc = inspect.getdoc(func) or ""
-    return param_info, return_annot, doc
-
-
-def _wrap_function_source(
-    name: str,
-    source: str,
-    doc: str,
-    param_info,
-    return_type: Optional[str],
-):
-    """
-    Creates a wrapped version of the function's source code with parameter and return type metadata
-    and docstring embedded as a header comment.
-    """
-    header = f"""
-Auto-logged transform function: {name}
-
-Args:
-"""
-    for p in param_info:
-        annotation = f" ({p['annotation']})" if p["annotation"] else ""
-        default = f", default={p['default']}" if p["default"] is not None else ""
-        header += f"  - {p['name']}{annotation}{default}\n"
-    header += f"\nReturns: {return_type or 'unspecified'}\n\n{doc}\n"
-    return f"{header}{source}"
 
 
 def log_transform_function(
@@ -129,6 +73,8 @@ def load_transform_function(
     filename = f"{artifact_path}/{name}.py"
     path = mlflow.artifacts.download_artifacts(run_id=run_id, artifact_path=filename)
     spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ValueError(f"Could not create module spec for {name}")
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
 
@@ -151,28 +97,9 @@ def find_transform_versions(name: str = None, return_type: str = None):
     """
     # Use parameters for structured data search
     filter_string = "tags.transform_type = 'pyspark'"
-    if name:
+    if name is not None:
         filter_string += f" AND params.transform_name = '{name}'"
-    if return_type:
+    if return_type is not None:
         filter_string += f" AND params.return_type = '{return_type}'"
 
     return mlflow.search_runs(filter_string=filter_string)
-
-
-def validate_transform_input(func: Callable, input_obj) -> bool:
-    """
-    Validates that the first argument's type of a transform function matches the input object's type.
-    """
-    sig = inspect.signature(func)
-    params = list(sig.parameters.values())
-    if not params:
-        return True  # no input to validate
-
-    first_param = params[0].name
-    hints = typing.get_type_hints(func)
-    expected_type = hints.get(first_param)
-    if expected_type is None:
-        return True
-
-    resolved = pydoc.locate(f"{expected_type.__module__}.{expected_type.__qualname__}")
-    return isinstance(input_obj, resolved) if resolved else False

--- a/src/pyspark_transform_registry/metadata.py
+++ b/src/pyspark_transform_registry/metadata.py
@@ -1,0 +1,60 @@
+import inspect
+import typing
+from typing import Callable, Optional
+
+
+def _resolve_fully_qualified_name(obj):
+    """Resolve the fully qualified name of an object."""
+    if obj is None:
+        return None
+    module = obj.__module__
+    qualname = getattr(obj, "__qualname__", obj.__name__)
+    return f"{module}.{qualname}"
+
+
+def _get_function_metadata(func: Callable):
+    """
+    Extracts parameter information, return type annotation, and docstring from a function.
+    """
+    sig = inspect.signature(func)
+    hints = typing.get_type_hints(func)
+    param_info = []
+    for name, param in sig.parameters.items():
+        annotation = hints.get(name)
+        param_info.append(
+            {
+                "name": name,
+                "annotation": _resolve_fully_qualified_name(annotation)
+                if annotation
+                else None,
+                "default": param.default if param.default != inspect._empty else None,
+            },
+        )
+    return_type = hints.get("return")
+    return_annot = _resolve_fully_qualified_name(return_type) if return_type else None
+    doc = inspect.getdoc(func) or ""
+    return param_info, return_annot, doc
+
+
+def _wrap_function_source(
+    name: str,
+    source: str,
+    doc: str,
+    param_info,
+    return_type: Optional[str],
+):
+    """
+    Creates a wrapped version of the function's source code with parameter and return type metadata
+    and docstring embedded as a header comment.
+    """
+    header = f"""
+Auto-logged transform function: {name}
+
+Args:
+"""
+    for p in param_info:
+        annotation = f" ({p['annotation']})" if p["annotation"] else ""
+        default = f", default={p['default']}" if p["default"] is not None else ""
+        header += f"  - {p['name']}{annotation}{default}\n"
+    header += f"\nReturns: {return_type or 'unspecified'}\n\n{doc}\n"
+    return f"{header}{source}"

--- a/src/pyspark_transform_registry/validation.py
+++ b/src/pyspark_transform_registry/validation.py
@@ -1,0 +1,23 @@
+import inspect
+import pydoc
+import typing
+from typing import Callable
+
+
+def validate_transform_input(func: Callable, input_obj) -> bool:
+    """
+    Validates that the first argument's type of a transform function matches the input object's type.
+    """
+    sig = inspect.signature(func)
+    params = list(sig.parameters.values())
+    if not params:
+        return True  # no input to validate
+
+    first_param = params[0].name
+    hints = typing.get_type_hints(func)
+    expected_type = hints.get(first_param)
+    if expected_type is None:
+        return True
+
+    resolved = pydoc.locate(f"{expected_type.__module__}.{expected_type.__qualname__}")
+    return isinstance(input_obj, resolved) if resolved and inspect.isclass(resolved) else False

--- a/tests/test_transform_registry.py
+++ b/tests/test_transform_registry.py
@@ -3,7 +3,7 @@ import pydoc
 import mlflow
 from pyspark.sql import DataFrame
 
-from main import (
+from pyspark_transform_registry import (
     _resolve_fully_qualified_name,
     find_transform_versions,
     log_transform_function,


### PR DESCRIPTION
Refactor `main.py` into a `src/pyspark_transform_registry` package to improve code organization and maintainability.